### PR TITLE
Remove store.Close

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,10 @@ import (
 	"github.com/jimeh/ozu.io/shortener"
 	"github.com/jimeh/ozu.io/storage/goleveldbstore"
 	"github.com/jimeh/ozu.io/web"
+	"github.com/syndtr/goleveldb/leveldb"
 )
+
+var path = "ozuio_database"
 
 func getPort() string {
 	port := os.Getenv("PORT")
@@ -19,11 +22,16 @@ func getPort() string {
 }
 
 func main() {
-	store, err := goleveldbstore.New("ozuio_database")
+	db, errDB := leveldb.OpenFile(path, nil)
+	if errDB != nil {
+		log.Fatal(errDB)
+	}
+	defer db.Close()
+
+	store, err := goleveldbstore.New(db)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer store.Close()
 
 	s := shortener.New(store)
 	server := web.NewServer(s)

--- a/shortener/mocks/Store.go
+++ b/shortener/mocks/Store.go
@@ -7,20 +7,6 @@ type Store struct {
 	mock.Mock
 }
 
-// Close provides a mock function with given fields:
-func (_m *Store) Close() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Delete provides a mock function with given fields: _a0
 func (_m *Store) Delete(_a0 []byte) error {
 	ret := _m.Called(_a0)

--- a/storage/goleveldbstore/store.go
+++ b/storage/goleveldbstore/store.go
@@ -14,12 +14,7 @@ var DefaultSequenceKey = []byte("__SEQUENCE_ID__")
 var ErrNotFound = errors.New("not found")
 
 // New creates a new Store using given path to persist data.
-func New(path string) (*Store, error) {
-	db, err := leveldb.OpenFile(path, nil)
-	if err != nil {
-		return &Store{}, err
-	}
-
+func New(db *leveldb.DB) (*Store, error) {
 	store := Store{
 		DB:          db,
 		SequenceKey: DefaultSequenceKey,
@@ -32,11 +27,6 @@ func New(path string) (*Store, error) {
 type Store struct {
 	DB          *leveldb.DB
 	SequenceKey []byte
-}
-
-// Close underlying goleveldb database.
-func (s *Store) Close() error {
-	return s.DB.Close()
 }
 
 // Get a given key's value.

--- a/storage/goleveldbstore/store_test.go
+++ b/storage/goleveldbstore/store_test.go
@@ -29,14 +29,16 @@ type StoreSuite struct {
 }
 
 func (s *StoreSuite) SetupTest() {
-	store, err := New(testDbPath)
+	db, errDB := leveldb.OpenFile(testDbPath, nil)
+	s.Require().NoError(errDB)
+	store, err := New(db)
 	s.Require().NoError(err)
 	s.store = store
-	s.db = store.DB
+	s.db = db
 }
 
 func (s *StoreSuite) TearDownTest() {
-	_ = s.store.Close()
+	_ = s.db.Close()
 	_ = os.RemoveAll(testDbPath)
 }
 
@@ -158,7 +160,8 @@ func TestStoreSuite(t *testing.T) {
 // Benchmarks
 
 func BenchmarkGet(b *testing.B) {
-	store, _ := New(testDbPath)
+	db, _ := leveldb.OpenFile(testDbPath, nil)
+	store, _ := New(db)
 
 	key := []byte("hello")
 	value := []byte("world")
@@ -168,12 +171,12 @@ func BenchmarkGet(b *testing.B) {
 		_, _ = store.Get(key)
 	}
 
-	_ = store.Close()
 	_ = os.RemoveAll(testDbPath)
 }
 
 func BenchmarkSet(b *testing.B) {
-	store, _ := New(testDbPath)
+	db, _ := leveldb.OpenFile(testDbPath, nil)
+	store, _ := New(db)
 
 	key := []byte("hello")
 	value := []byte("world")
@@ -182,29 +185,28 @@ func BenchmarkSet(b *testing.B) {
 		_ = store.Set(append(key, string(n)...), value)
 	}
 
-	_ = store.Close()
 	_ = os.RemoveAll(testDbPath)
 }
 
 func BenchmarkNextSequence(b *testing.B) {
-	store, _ := New(testDbPath)
+	db, _ := leveldb.OpenFile(testDbPath, nil)
+	store, _ := New(db)
 
 	for n := 0; n < b.N; n++ {
 		_, _ = store.NextSequence()
 	}
 
-	_ = store.Close()
 	_ = os.RemoveAll(testDbPath)
 }
 
 func BenchmarkIncr(b *testing.B) {
-	store, _ := New(testDbPath)
+	db, _ := leveldb.OpenFile(testDbPath, nil)
+	store, _ := New(db)
 
 	key := []byte("incr-benchmark-counter")
 	for n := 0; n < b.N; n++ {
 		_, _ = store.Incr(key)
 	}
 
-	_ = store.Close()
 	_ = os.RemoveAll(testDbPath)
 }

--- a/storage/inmemorystore/store.go
+++ b/storage/inmemorystore/store.go
@@ -22,14 +22,6 @@ type Store struct {
 	sync.RWMutex
 	Data     map[string][]byte
 	Sequence int
-	Closed   bool
-}
-
-// Close database.
-func (s *Store) Close() error {
-	s.Data = make(map[string][]byte)
-	s.Sequence = 0
-	return nil
 }
 
 // Get a given key's value.

--- a/storage/inmemorystore/store_test.go
+++ b/storage/inmemorystore/store_test.go
@@ -29,10 +29,6 @@ func (s *StoreSuite) SetupTest() {
 	s.store = store
 }
 
-func (s *StoreSuite) TearDownTest() {
-	_ = s.store.Close()
-}
-
 func (s *StoreSuite) Seed() {
 	for _, e := range examples {
 		s.store.Data[string(e.key)] = e.value
@@ -136,8 +132,6 @@ func BenchmarkGet(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		_, _ = store.Get(key)
 	}
-
-	_ = store.Close()
 }
 
 func BenchmarkSet(b *testing.B) {
@@ -149,8 +143,6 @@ func BenchmarkSet(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		_ = store.Set(append(key, string(n)...), value)
 	}
-
-	_ = store.Close()
 }
 
 func BenchmarkNextSequence(b *testing.B) {
@@ -159,6 +151,4 @@ func BenchmarkNextSequence(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		_, _ = store.NextSequence()
 	}
-
-	_ = store.Close()
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -1,8 +1,7 @@
 package storage
 
-// Storage defines a standard interface for storage.
+// Store defines a standard interface for storage.
 type Store interface {
-	Close() error
 	Get([]byte) ([]byte, error)
 	Set([]byte, []byte) error
 	Delete([]byte) error


### PR DESCRIPTION
Suggestion to remove `store.Close` as it is specific to BoltDB and other file based persistence libs.
